### PR TITLE
Fix bcdedit "advancedoptions off" issue.

### DIFF
--- a/setup.cmd
+++ b/setup.cmd
@@ -137,7 +137,7 @@ echo to a moment before the crash. The installer included in this package enable
 echo so that entering Safe mode to access system restore is much easier, avoiding further crashes. Advanced startup menu
 echo is then disabled if installation completes sucessfully. An utility that disables advanced startup menu on demand is included.)>"%~dp0recovery.txt"
 @echo Reverting Windows to normal startup...
-@bcdedit /set {globalsettings} advancedoptions false
+@bcdedit /deletevalue {globalsettings} advancedoptions
 @echo.
 
 :checkreboot


### PR DESCRIPTION
The "bcdedit /set {globalsettings} advancedoptions false" command breaks Windows 10 ability to restart with the advanced options menu when you try to access this menu when using "Settings -> Update & Security -> Recovery -> Advanced Start up".

By default this entry is not present in Windows 10 in the bcedit {globalsettings} store. Setting advancedoptions to "false" in the {globalsettings} store does not simply turn off this setting; it overrides, and enforces the value of advancedoptions to "false", globally, preventing Windows from activating this menu from the advanced start up menu in the Recovery options.


More about bcdedit here: 
https://docs.microsoft.com/en-us/windows-hardware/drivers/devtest/bcdedit--set