### PR TITLE
Fix: Prevent premature reboot in deluadcomponent.cmd

### DIFF
--- a/modules/deluadcomponent.cmd
+++ b/modules/deluadcomponent.cmd
@@ -22,7 +22,7 @@ set /a loopcount+=1
 set /a scandrvpos+=1
 set drvval=%%b
 IF !scandrvpos! EQU !pubdrvpos! echo Removing Realtek UAD component %1 instance #!loopcount!...
-IF !scandrvpos! EQU !pubdrvpos! pnputil /delete-driver !drvval: =! /force /reboot /uninstall
+IF !scandrvpos! EQU !pubdrvpos! pnputil /delete-driver !drvval: =! /force /norestart /uninstall
 IF !scandrvpos! EQU !pubdrvpos! echo.
 )
 @IF NOT !pubdrvpos! EQU -1 GOTO delcmploop


### PR DESCRIPTION
The /reboot flag in the pnputil command caused the system to restart after deleting a single driver instance, preventing the script from removing multiple instances in one pass.

This commit replaces the /reboot flag with /norestart to allow the script to complete the uninstallation of all components before a reboot occurs.